### PR TITLE
Performance command

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-requirements = ["Click", "requests", "python-dateutil"]
+requirements = ["Click", "requests", "python-dateutil", "prettytable"]
 
 setup(
     name="utopian",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ requirements = ["Click", "requests", "python-dateutil", "prettytable"]
 
 setup(
     name="utopian",
-    version="0.2.1",
+    version="0.3.0",
     description="A CLI for the Utopian.io API.",
     license="MIT",
     author="amosbastian",

--- a/utopian/utopian.py
+++ b/utopian/utopian.py
@@ -361,17 +361,22 @@ def moderator_details(authors, limit):
 
 @cli.command()
 @click.argument("account", type=str)
-@click.option("--date", type=DATE)
-@click.option("--days", type=int)
+@click.option("--date", type=DATE,
+    help="See performance for the time period [NOW] - [DATE]")
+@click.option("--days", type=int,
+    help="See performance for the last N days.")
 @click.option("--contributor", "account_type", flag_value="contributor",
-    default=True)
-@click.option("--moderator", "account_type", flag_value="moderator")
-@click.option("--details", is_flag=True)
-@click.option("--limit", default=10)
+    default=True, help="See performance as a contributor.")
+@click.option("--moderator", "account_type", flag_value="moderator",
+    help="See performance as a moderator.")
+@click.option("--details", is_flag=True,
+    help="See more details about who you have reviewed/has reviewed you.")
+@click.option("--limit", default=10,
+    help="Limit the --details table to the top N authors/moderators.")
 def performance(account_type, account, date, days, details, limit):
     """
-    Takes a given date and account name and analyses the account's reviewed
-    contributions from now until the given date.
+    Takes a given account and either shows the account's performance as a 
+    contributor or as a moderator (if applicable) in a given time period.
     """
     if (date and days) or (not date and not days):
         click.echo("Choose either an amount of days or a specific date.")

--- a/utopian/utopian.py
+++ b/utopian/utopian.py
@@ -185,7 +185,7 @@ def percentage(accepted, rejected):
     if rejected == 0:
         return 0
     else:
-        return accepted / rejected
+        return float(accepted) / rejected * 100
 
 @cli.command()
 @click.argument("date", type=DATE)
@@ -246,4 +246,6 @@ def performance(date, account):
         table.add_row(["all", total_accepted + total_rejected, total_accepted,
             total_rejected, "{:.2f}%".format(percentage(total_accepted,
                 total_rejected)), total_points])
+        table.align = "r"
+        table.align["Category"] = "l"
         click.echo(table)

--- a/utopian/utopian.py
+++ b/utopian/utopian.py
@@ -200,9 +200,13 @@ def contributor_dictionary(response, date):
         if date < parse(contribution["created"]):
             moderator = contribution["moderator"]
             category = contribution["json_metadata"]["type"]
-            reward = float(contribution["pending_payout_value"].split(" ")[0])
+            reward = round(
+                float(contribution["pending_payout_value"].split(" ")[0]))
             if reward == 0:
-                reward = float(contribution["total_payout_value"].split(" ")[0])
+                author = float(contribution["total_payout_value"].split(" ")[0])
+                curator = float(
+                    contribution["curator_payout_value"].split(" ")[0])
+                reward = round(author + curator)
             contributed_categories.setdefault(category, {
                     "accepted" : 0,
                     "rejected" : 0,
@@ -292,9 +296,10 @@ def contributor_table(contributed_categories):
         reward = value["reward"]
         rejected = value["rejected"]
         accepted_pct = "{}%".format(percentage(accepted, rejected))
-        reward = "{}$".format(reward)
+        post_reward = "{}$".format(reward)
 
-        table.add_row([key, reviewed, accepted, rejected, accepted_pct,reward])
+        table.add_row([key, reviewed, accepted, rejected, accepted_pct,
+            post_reward])
         total_accepted += accepted
         total_reward += reward
         total_rejected += rejected

--- a/utopian/utopian.py
+++ b/utopian/utopian.py
@@ -150,7 +150,7 @@ def sponsors(j, account):
 
 class Date(click.ParamType):
     """
-    A custom type for the approved command.
+    A custom type for the performance command.
     """
     name = "date"
 
@@ -394,12 +394,19 @@ def performance(account_type, account, date, days, details, limit):
             table = moderator_details(authors, limit)
         click.echo(table)
     elif account_type == "contributor":
-        total = requests.get(build_url("posts", {"section" : "author", 
+        total_accepted = requests.get(build_url("posts", {"section" : "author", 
             "limit" : 1, "author" : account})).json()["total"]
-        response = requests.get(build_url("posts", {"section" : "author", 
-            "limit" : total, "author" : account})).json()["results"]
+        accepted = requests.get(build_url("posts", {"section" : "author", 
+            "limit" : total_accepted, "author" : account})).json()["results"]
+        total_rejected = requests.get(build_url("posts", {"section" : "author", 
+            "limit" : 1, "author" : account, "status" : "flagged"}
+            )).json()["total"]
+        rejected = requests.get(build_url("posts", {"section" : "author", 
+            "limit" : total_accepted, "author" : account, "status" : "flagged"}
+            )).json()["results"]
 
-        contributed_categories, moderators = contributor_dictionary(response,
+        accepted.extend(rejected)
+        contributed_categories, moderators = contributor_dictionary(accepted,
             date)
         if not details:
             table = contributor_table(contributed_categories)


### PR DESCRIPTION
Rename the points command to performance and add a lot of new options, as seen below

```
Usage: utopian performance [OPTIONS] ACCOUNT

  Takes a given account and either shows the account's performance as a
  contributor or as a moderator (if applicable) in a given time period.

Options:
  --date DATE      See performance for the time period [NOW] - [DATE]
  --days INTEGER   See performance for the last N days.
  --contributor    See performance as a contributor.
  --moderator      See performance as a moderator.
  --details        See more details about who you have reviewed/has reviewed
                   you.
  --limit INTEGER  Limit the --details table to the top N authors/moderators.
  --help           Show this message and exit.
```